### PR TITLE
Fix long questions not wrapped in IE.

### DIFF
--- a/adventure/public/css/adventure.css
+++ b/adventure/public/css/adventure.css
@@ -44,6 +44,7 @@
 
 .adventure .question {
     margin-bottom: 1em;
+    max-width: 100%;
 }
 
 .adventure .choice-label {


### PR DESCRIPTION
https://edx-wiki.atlassian.net/browse/MCKIN-3737

Long text inside legend element does not wrap in IE by default,
unless you limit the legend's width.

Setting max-width to 100% seems to do the trick.

Tested in IE 10 & 11, latest Chrome, FF, and Safari.