### PR TITLE
[MCKIN-9138] Mark block completed on submit instead of on view

### DIFF
--- a/adventure/adventure.py
+++ b/adventure/adventure.py
@@ -33,6 +33,7 @@ from StringIO import StringIO
 from mentoring.light_children import XBlockWithLightChildren
 from mentoring import TitleBlock
 
+from xblock.completable import CompletableXBlockMixin
 from xblock.core import XBlock
 from xblock.fields import Scope, String, Integer, List
 from xblock.fragment import Fragment
@@ -112,7 +113,7 @@ DEFAULT_XML_CONTENT = textwrap.dedent("""\
 # Classes ###########################################################
 
 @XBlock.wants("settings")
-class AdventureBlock(XBlockWithLightChildren):
+class AdventureBlock(CompletableXBlockMixin, XBlockWithLightChildren):
     """
     An XBlock providing adventure capabilities
 
@@ -438,7 +439,7 @@ class AdventureBlock(XBlockWithLightChildren):
         if 'choice' in submissions:
             self._save_student_choice(submissions)
         self.current_step_name = next_step.name
-        self.runtime.publish(self, 'progress', {})
+        self.emit_completion(1.0)
 
         return self._render_current_step()
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ BLOCKS_CHILDREN = [
 
 setup(
     name='xblock-adventure',
-    version='0.1',
+    version='0.1.1',
     description='XBlock - Adventure',
     packages=['adventure'],
     install_requires=[


### PR DESCRIPTION
Updates the block to mark completion on submission instead of on view. 

**Testing instructions**:
1. Install master branch of xblock-adventure 
2. Create a new unit with just a single xblock-adventure block
3. Log in as a student and view the unit with the block. 
4. Keep a lookout in the network activity, you will see a POST request to the block's ``publsh_completion`` handler. (After takes 5 seconds)
5. Notice that the vertical is marked as complete. 
6. Repeats the steps 2 and 3 after installing the block from this PR
7. Notice there is no POST to ``publish_completion`` despite waiting 6 seconds or more. 
8. If you refresh the page you'll see that the vertical is not marked as complete. 
9. Now complete the block.
10. Refresh the page, the vertical should be marked as complete. 
