### PR TITLE
MCKIN-28307 - Remove 3Play API Key retreival

### DIFF
--- a/adventure/adventure.py
+++ b/adventure/adventure.py
@@ -318,14 +318,6 @@ class AdventureBlock(CompletableXBlockMixin, XBlockWithLightChildren):
 
         return response
 
-    # TODO find a better way, to avoid duplication of this (needed for ooyala child)
-    def api_key_3play_from_default_setting(self):
-        settings_service = self.runtime.service(self, 'settings')
-        try:
-            return settings_service.get('ENV_TOKENS')['XBLOCK_OOYALA_3PLAY_API']
-        except (AttributeError, KeyError):
-            return ''
-
     @property
     def i18n_service(self):
         """ Obtains translation service """
@@ -377,9 +369,6 @@ class AdventureBlock(CompletableXBlockMixin, XBlockWithLightChildren):
             step = self._get_step_by_name(context_step_name)
             for child in step.get_children_objects():
                 if child.name == context_step_child_name:
-                    # 3play api key from setting
-                    if not child.api_key_3play:
-                        child.api_key_3play = self.api_key_3play_from_default_setting()
                     return child.student_view(context)
 
         # First access, set the current_step to the beginning of the adventure

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ BLOCKS_CHILDREN = [
 
 setup(
     name='xblock-adventure',
-    version='0.4.1',
+    version='0.4.2',
     description='XBlock - Adventure',
     packages=['adventure'],
     install_requires=[


### PR DESCRIPTION
Removing 3Play API Key retrieval because:

- It is not needed, video xblock itself load this value
- This code breaks with exception when attribute is not found
